### PR TITLE
Stillshot Stability Improvements

### DIFF
--- a/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
+++ b/library/src/main/java/com/afollestad/materialcamera/MaterialCamera.java
@@ -269,7 +269,7 @@ public class MaterialCamera {
     }
 
     public Intent getIntent() {
-        final Class<?> cls = !mForceCamera1 && CameraUtil.hasCamera2(mContext) ?
+        final Class<?> cls = !mForceCamera1 && CameraUtil.hasCamera2(mContext, mStillShot) ?
                 CaptureActivity2.class : CaptureActivity.class;
         Intent intent = new Intent(mContext, cls)
                 .putExtra(CameraIntentKey.LENGTH_LIMIT, mLengthLimit)

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCameraFragment.java
@@ -284,6 +284,7 @@ abstract class BaseCameraFragment extends Fragment implements CameraUriInterface
                     mInterface.iconFrontCamera() : mInterface.iconRearCamera());
             closeCamera();
             openCamera();
+            setupFlashMode();
         } else if (id == R.id.video) {
             if (mIsRecording) {
                 stopRecordingVideo(false);
@@ -317,6 +318,13 @@ abstract class BaseCameraFragment extends Fragment implements CameraUriInterface
     }
 
     private void setupFlashMode() {
+        if (mInterface.shouldHideFlash()) {
+            mButtonFlash.setVisibility(View.GONE);
+            return;
+        } else {
+            mButtonFlash.setVisibility(View.VISIBLE);
+        }
+
         final int res;
         switch (mInterface.getFlashMode()) {
             case FLASH_MODE_AUTO:

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -49,8 +49,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     private Object mFrontCameraId;
     private Object mBackCameraId;
     private boolean mDidRecord = false;
-    private int[] mFlashModes;
-    private Boolean mFlashButtonVisible;
+    private List<Integer> mFlashModes;
 
     public static final int PERMISSION_RC = 69;
 
@@ -411,21 +410,8 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
 
     @Override
     public void toggleFlashMode() {
-        /*switch (mFlashMode) {
-            case FLASH_MODE_AUTO:
-                mFlashMode = FLASH_MODE_ALWAYS_ON;
-                break;
-            case FLASH_MODE_ALWAYS_ON:
-                mFlashMode = FLASH_MODE_OFF;
-                break;
-            case FLASH_MODE_OFF:
-            default:
-                mFlashMode = FLASH_MODE_AUTO;
-        }*/
-        if(mFlashModes != null) {
-            int index = (Arrays.asList(mFlashModes).indexOf(mFlashMode));
-
-            mFlashMode = mFlashModes[(Arrays.asList(mFlashModes).indexOf(mFlashMode) + 1) % mFlashModes.length];
+        if (mFlashModes != null) {
+            mFlashMode = mFlashModes.get((mFlashModes.indexOf(mFlashMode) + 1) % mFlashModes.size());
         }
     }
 
@@ -558,26 +544,12 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     }
 
     @Override
-    public void setFlashModes(List<String> modes) {
-        if(modes == null){
-            mFlashModes = null;
-            return;
-        }
-        mFlashModes = new int[modes.size()];
-        for(int i = 0; i < modes.size(); i++){
-            switch(modes.get(i)){
-                case Camera.Parameters.FLASH_MODE_AUTO:
-                    mFlashModes[i] = FLASH_MODE_AUTO;
-                    break;
-                case Camera.Parameters.FLASH_MODE_ON:
-                    mFlashModes[i] = FLASH_MODE_ALWAYS_ON;
-                    break;
-                case Camera.Parameters.FLASH_MODE_OFF:
-                    mFlashModes[i] = FLASH_MODE_OFF;
-                    break;
-                default:
-                    break;
-            }
-        }
+    public void setFlashModes(List<Integer> modes) {
+        mFlashModes = modes;
+    }
+
+    @Override
+    public boolean shouldHideFlash() {
+        return mFlashModes == null;
     }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -144,24 +144,28 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
             showInitialRecorder();
             return;
         }
-        final boolean videoGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
+        final boolean cameraGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED;
         final boolean audioGranted = ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED;
         final boolean audioNeeded = !useStillshot();
 
-        if (videoGranted && !audioGranted && audioNeeded) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO}, PERMISSION_RC);
-            mRequestingPermission = true;
+        String[] perms = null;
+        if (cameraGranted) {
+            if (audioNeeded && !audioGranted) {
+                perms = new String[]{Manifest.permission.RECORD_AUDIO};
+            }
+        } else {
+            if (audioNeeded && !audioGranted) {
+                perms = new String[]{Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO};
+            } else {
+                perms = new String[]{Manifest.permission.CAMERA};
+            }
         }
 
-        if (videoGranted) {
-            showInitialRecorder();
-        } else {
-            String[] perms;
-            if (audioGranted) perms = new String[]{Manifest.permission.CAMERA};
-            else if(audioNeeded) perms = new String[]{Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO};
-            else perms = new String[]{Manifest.permission.CAMERA};
+        if (perms != null) {
             ActivityCompat.requestPermissions(this, perms, PERMISSION_RC);
             mRequestingPermission = true;
+        } else {
+            showInitialRecorder();
         }
     }
 
@@ -550,10 +554,6 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
 
     @Override
     public boolean shouldHideFlash() {
-        if(!useStillshot()){
-            return true;
-        } else {
-            return mFlashModes == null;
-        }
+        return !useStillshot() || mFlashModes == null;
     }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -6,6 +6,7 @@ import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.hardware.Camera;
 import android.media.CamcorderProfile;
 import android.net.Uri;
 import android.os.Build;
@@ -30,6 +31,9 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import java.io.File;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Aidan Follestad (afollestad)
@@ -37,7 +41,7 @@ import java.lang.annotation.RetentionPolicy;
 public abstract class BaseCaptureActivity extends AppCompatActivity implements BaseCaptureInterface {
 
     private int mCameraPosition = CAMERA_POSITION_UNKNOWN;
-    private int mFlashMode = FLASH_MODE_AUTO;
+    private int mFlashMode = FLASH_MODE_OFF;
     private boolean mRequestingPermission;
     private long mRecordingStart = -1;
     private long mRecordingEnd = -1;
@@ -45,6 +49,8 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
     private Object mFrontCameraId;
     private Object mBackCameraId;
     private boolean mDidRecord = false;
+    private int[] mFlashModes;
+    private Boolean mFlashButtonVisible;
 
     public static final int PERMISSION_RC = 69;
 
@@ -405,7 +411,7 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
 
     @Override
     public void toggleFlashMode() {
-        switch (mFlashMode) {
+        /*switch (mFlashMode) {
             case FLASH_MODE_AUTO:
                 mFlashMode = FLASH_MODE_ALWAYS_ON;
                 break;
@@ -415,6 +421,11 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
             case FLASH_MODE_OFF:
             default:
                 mFlashMode = FLASH_MODE_AUTO;
+        }*/
+        if(mFlashModes != null) {
+            int index = (Arrays.asList(mFlashModes).indexOf(mFlashMode));
+
+            mFlashMode = mFlashModes[(Arrays.asList(mFlashModes).indexOf(mFlashMode) + 1) % mFlashModes.length];
         }
     }
 
@@ -546,4 +557,27 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
         return getIntent().getIntExtra(CameraIntentKey.ICON_FLASH_OFF, R.drawable.mcam_action_flash_off);
     }
 
+    @Override
+    public void setFlashModes(List<String> modes) {
+        if(modes == null){
+            mFlashModes = null;
+            return;
+        }
+        mFlashModes = new int[modes.size()];
+        for(int i = 0; i < modes.size(); i++){
+            switch(modes.get(i)){
+                case Camera.Parameters.FLASH_MODE_AUTO:
+                    mFlashModes[i] = FLASH_MODE_AUTO;
+                    break;
+                case Camera.Parameters.FLASH_MODE_ON:
+                    mFlashModes[i] = FLASH_MODE_ALWAYS_ON;
+                    break;
+                case Camera.Parameters.FLASH_MODE_OFF:
+                    mFlashModes[i] = FLASH_MODE_OFF;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureActivity.java
@@ -550,6 +550,10 @@ public abstract class BaseCaptureActivity extends AppCompatActivity implements B
 
     @Override
     public boolean shouldHideFlash() {
-        return mFlashModes == null;
+        if(!useStillshot()){
+            return true;
+        } else {
+            return mFlashModes == null;
+        }
     }
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
@@ -126,6 +126,8 @@ public interface BaseCaptureInterface {
     @DrawableRes
     int iconFlashOff();
 
-    void setFlashModes(List<String> modes);
+    void setFlashModes(List<Integer> modes);
+
+    boolean shouldHideFlash();
 
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/BaseCaptureInterface.java
@@ -4,6 +4,8 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 
+import java.util.List;
+
 /**
  * @author Aidan Follestad (afollestad)
  */
@@ -123,5 +125,7 @@ public interface BaseCaptureInterface {
 
     @DrawableRes
     int iconFlashOff();
+
+    void setFlashModes(List<String> modes);
 
 }

--- a/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/Camera2Fragment.java
@@ -628,8 +628,7 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
 
             configureTransform(width, height);
 
-            Boolean flashAvailable = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
-            mFlashSupported = flashAvailable == null ? false : flashAvailable;
+            mInterface.setFlashModes(CameraUtil.getSupportedFlashModes(getActivity(), characteristics));
 
             // noinspection ResourceType
             manager.openCamera((String) mInterface.getCurrentCameraId(), mStateCallback, null);
@@ -1032,30 +1031,28 @@ public class Camera2Fragment extends BaseCameraFragment implements View.OnClickL
     }
 
     private void setFlashMode(CaptureRequest.Builder requestBuilder) {
-        if (mFlashSupported) {
-            mPreviewBuilder.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
+        mPreviewBuilder.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO);
 
-            int aeMode;
-            int flashMode;
-            switch (mInterface.getFlashMode()) {
-                case FLASH_MODE_AUTO:
-                    aeMode = CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH;
-                    flashMode = CameraMetadata.FLASH_MODE_SINGLE;
-                    break;
-                case FLASH_MODE_ALWAYS_ON:
-                    aeMode = CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH;
-                    flashMode = CameraMetadata.FLASH_MODE_TORCH;
-                    break;
-                case FLASH_MODE_OFF:
-                default:
-                    aeMode = CaptureRequest.CONTROL_AE_MODE_ON;
-                    flashMode = CameraMetadata.FLASH_MODE_OFF;
-                    break;
-            }
-
-            requestBuilder.set(CaptureRequest.CONTROL_AE_MODE, aeMode);
-            requestBuilder.set(CaptureRequest.FLASH_MODE, flashMode);
+        int aeMode;
+        int flashMode;
+        switch (mInterface.getFlashMode()) {
+            case FLASH_MODE_AUTO:
+                aeMode = CaptureRequest.CONTROL_AE_MODE_ON_AUTO_FLASH;
+                flashMode = CameraMetadata.FLASH_MODE_SINGLE;
+                break;
+            case FLASH_MODE_ALWAYS_ON:
+                aeMode = CaptureRequest.CONTROL_AE_MODE_ON_ALWAYS_FLASH;
+                flashMode = CameraMetadata.FLASH_MODE_TORCH;
+                break;
+            case FLASH_MODE_OFF:
+            default:
+                aeMode = CaptureRequest.CONTROL_AE_MODE_ON;
+                flashMode = CameraMetadata.FLASH_MODE_OFF;
+                break;
         }
+
+        requestBuilder.set(CaptureRequest.CONTROL_AE_MODE, aeMode);
+        requestBuilder.set(CaptureRequest.FLASH_MODE, flashMode);
     }
 
     //////////////////////// END OF STILL SHOT

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -45,7 +45,7 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
     private Point mWindowSize;
     private int mDisplayOrientation;
     private boolean mIsAutoFocusing;
-    List<String> mFlashModes;
+    List<Integer> mFlashModes;
 
     public static CameraFragment newInstance() {
         CameraFragment fragment = new CameraFragment();
@@ -209,7 +209,6 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
                 parameters.setRecordingHint(true);
 
-            System.out.println(parameters.getSupportedFlashModes().toString() + "====================================================================================================");
             mFlashModes = CameraUtil.getSupportedFlashModes(this.getActivity(), parameters);
             mInterface.setFlashModes(mFlashModes);
             System.out.println("Modes after parse: " + ((mFlashModes == null) ? "null": mFlashModes.toString()) + "====================================================================================================");
@@ -458,24 +457,24 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
     }
 
     private void setupFlashMode() {
-            String flashMode = null;
-            switch (mInterface.getFlashMode()) {
-                case FLASH_MODE_AUTO:
-                    flashMode = Camera.Parameters.FLASH_MODE_AUTO;
-                    break;
-                case FLASH_MODE_ALWAYS_ON:
-                    flashMode = Camera.Parameters.FLASH_MODE_ON;
-                    break;
-                case FLASH_MODE_OFF:
-                    flashMode = Camera.Parameters.FLASH_MODE_OFF;
-                default:
-                    break;
-            }
-            if(flashMode != null) {
-                Camera.Parameters parameters = mCamera.getParameters();
-                parameters.setFlashMode(flashMode);
-                mCamera.setParameters(parameters);
-            }
+        String flashMode = null;
+        switch (mInterface.getFlashMode()) {
+            case FLASH_MODE_AUTO:
+                flashMode = Camera.Parameters.FLASH_MODE_AUTO;
+                break;
+            case FLASH_MODE_ALWAYS_ON:
+                flashMode = Camera.Parameters.FLASH_MODE_ON;
+                break;
+            case FLASH_MODE_OFF:
+                flashMode = Camera.Parameters.FLASH_MODE_OFF;
+            default:
+                break;
+        }
+        if(flashMode != null) {
+            Camera.Parameters parameters = mCamera.getParameters();
+            parameters.setFlashMode(flashMode);
+            mCamera.setParameters(parameters);
+        }
     }
 
     @Override

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -21,6 +21,7 @@ import com.afollestad.materialcamera.R;
 import com.afollestad.materialcamera.util.CameraUtil;
 import com.afollestad.materialcamera.util.Degrees;
 import com.afollestad.materialcamera.util.ImageUtils;
+import com.afollestad.materialcamera.util.ManufacturerUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -206,12 +207,10 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
             Camera.Size previewSize = chooseOptimalSize(parameters.getSupportedPreviewSizes(),
                     mWindowSize.x, mWindowSize.y, mVideoSize);
 
-            // some Samsung S3 devices
-            final String SAMSUNG_S3_DEVICE_COMMON_PREFIX = "d2";
-            if (Build.DEVICE.startsWith(SAMSUNG_S3_DEVICE_COMMON_PREFIX)) {
-                final Integer SAMSUNG_S3_PREVIEW_WIDTH = 640;
-                final Integer SAMSUNG_S3_PREVIEW_HEIGHT = 480;
-                parameters.setPreviewSize(SAMSUNG_S3_PREVIEW_WIDTH, SAMSUNG_S3_PREVIEW_HEIGHT);
+
+            if (ManufacturerUtil.isSamsungGalaxyS3()) {
+                parameters.setPreviewSize(ManufacturerUtil.SAMSUNG_S3_PREVIEW_WIDTH,
+                                          ManufacturerUtil.SAMSUNG_S3_PREVIEW_HEIGHT);
             } else {
                 parameters.setPreviewSize(previewSize.width, previewSize.height);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -207,9 +207,12 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                     mWindowSize.x, mWindowSize.y, mVideoSize);
 
             // some Samsung S3 devices
-            if (Build.DEVICE.startsWith("d2"))
-                parameters.setPreviewSize(640,480);
-            else {
+            final String SAMSUNG_S3_DEVICE_COMMON_PREFIX = "d2";
+            if (Build.DEVICE.startsWith(SAMSUNG_S3_DEVICE_COMMON_PREFIX)) {
+                final Integer SAMSUNG_S3_PREVIEW_WIDTH = 640;
+                final Integer SAMSUNG_S3_PREVIEW_HEIGHT = 480;
+                parameters.setPreviewSize(SAMSUNG_S3_PREVIEW_WIDTH, SAMSUNG_S3_PREVIEW_HEIGHT);
+            } else {
                 parameters.setPreviewSize(previewSize.width, previewSize.height);
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
                     parameters.setRecordingHint(true);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -20,7 +20,7 @@ import com.afollestad.materialcamera.ICallback;
 import com.afollestad.materialcamera.R;
 import com.afollestad.materialcamera.util.CameraUtil;
 import com.afollestad.materialcamera.util.Degrees;
-import com.afollestad.materialcamera.util.ImageUtils;
+import com.afollestad.materialcamera.util.ImageUtil;
 import com.afollestad.materialcamera.util.ManufacturerUtil;
 
 import java.io.File;
@@ -515,7 +515,7 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                 final File outputPic = getOutputPictureFile();
 
                 // lets save the image to disk
-                ImageUtils.saveToDiskAsync(data, outputPic, new ICallback() {
+                ImageUtil.saveToDiskAsync(data, outputPic, new ICallback() {
                     @Override
                     public void done(Exception e) {
                         if (e == null) {

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -45,7 +45,7 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
     private Point mWindowSize;
     private int mDisplayOrientation;
     private boolean mIsAutoFocusing;
-    boolean mFlashSupported;
+    List<String> mFlashModes;
 
     public static CameraFragment newInstance() {
         CameraFragment fragment = new CameraFragment();
@@ -209,7 +209,10 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
                 parameters.setRecordingHint(true);
 
-            mFlashSupported = parameters.getSupportedFlashModes() != null; // TODO which supported
+            System.out.println(parameters.getSupportedFlashModes().toString() + "====================================================================================================");
+            mFlashModes = CameraUtil.getSupportedFlashModes(this.getActivity(), parameters);
+            mInterface.setFlashModes(mFlashModes);
+            System.out.println("Modes after parse: " + ((mFlashModes == null) ? "null": mFlashModes.toString()) + "====================================================================================================");
 
             Camera.Size mStillShotSize = getHighestSupportedStillShotSize(parameters.getSupportedPictureSizes());
             parameters.setPictureSize(mStillShotSize.width, mStillShotSize.height);
@@ -455,8 +458,7 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
     }
 
     private void setupFlashMode() {
-        if (mFlashSupported) {
-            String flashMode;
+            String flashMode = null;
             switch (mInterface.getFlashMode()) {
                 case FLASH_MODE_AUTO:
                     flashMode = Camera.Parameters.FLASH_MODE_AUTO;
@@ -465,14 +467,15 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
                     flashMode = Camera.Parameters.FLASH_MODE_ON;
                     break;
                 case FLASH_MODE_OFF:
-                default:
                     flashMode = Camera.Parameters.FLASH_MODE_OFF;
+                default:
                     break;
             }
-            Camera.Parameters parameters = mCamera.getParameters();
-            parameters.setFlashMode(flashMode);
-            mCamera.setParameters(parameters);
-        }
+            if(flashMode != null) {
+                Camera.Parameters parameters = mCamera.getParameters();
+                parameters.setFlashMode(flashMode);
+                mCamera.setParameters(parameters);
+            }
     }
 
     @Override

--- a/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/CameraFragment.java
@@ -205,13 +205,19 @@ public class CameraFragment extends BaseCameraFragment implements View.OnClickLi
             mVideoSize = chooseVideoSize((BaseCaptureActivity) activity, videoSizes);
             Camera.Size previewSize = chooseOptimalSize(parameters.getSupportedPreviewSizes(),
                     mWindowSize.x, mWindowSize.y, mVideoSize);
-            parameters.setPreviewSize(previewSize.width, previewSize.height);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
-                parameters.setRecordingHint(true);
+
+            // some Samsung S3 devices
+            if (Build.DEVICE.startsWith("d2"))
+                parameters.setPreviewSize(640,480);
+            else {
+                parameters.setPreviewSize(previewSize.width, previewSize.height);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+                    parameters.setRecordingHint(true);
+            }
+
 
             mFlashModes = CameraUtil.getSupportedFlashModes(this.getActivity(), parameters);
             mInterface.setFlashModes(mFlashModes);
-            System.out.println("Modes after parse: " + ((mFlashModes == null) ? "null": mFlashModes.toString()) + "====================================================================================================");
 
             Camera.Size mStillShotSize = getHighestSupportedStillShotSize(parameters.getSupportedPictureSizes());
             parameters.setPictureSize(mStillShotSize.width, mStillShotSize.height);

--- a/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
@@ -11,7 +11,7 @@ import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 
 import com.afollestad.materialcamera.R;
-import com.afollestad.materialcamera.util.ImageUtils;
+import com.afollestad.materialcamera.util.ImageUtil;
 
 /**
  * Created by tomiurankar on 04/03/16.
@@ -71,7 +71,7 @@ public class StillshotPreviewFragment extends BaseGalleryFragment {
         final int height = mImageView.getMeasuredHeight();
 
         if (mBitmap == null) {
-            Bitmap bitmap = ImageUtils.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height);
+            Bitmap bitmap = ImageUtil.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height);
             mBitmap = bitmap;
         }
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
@@ -71,7 +71,7 @@ public class StillshotPreviewFragment extends BaseGalleryFragment {
         final int height = mImageView.getMeasuredHeight();
 
         if (mBitmap == null) {
-            Bitmap bitmap = ImageUtils.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height, 1);
+            Bitmap bitmap = ImageUtils.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height);
             mBitmap = bitmap;
         }
 

--- a/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
+++ b/library/src/main/java/com/afollestad/materialcamera/internal/StillshotPreviewFragment.java
@@ -71,7 +71,7 @@ public class StillshotPreviewFragment extends BaseGalleryFragment {
         final int height = mImageView.getMeasuredHeight();
 
         if (mBitmap == null) {
-            Bitmap bitmap = ImageUtils.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height);
+            Bitmap bitmap = ImageUtils.getRotatedBitmap(Uri.parse(mOutputUri).getPath(), width, height, 1);
             mBitmap = bitmap;
         }
 

--- a/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Matrix;
+import android.hardware.Camera;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
 import android.media.ExifInterface;
@@ -23,8 +24,11 @@ import com.afollestad.materialcamera.ICallback;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
@@ -62,6 +66,20 @@ public class CameraUtil {
     public static boolean hasCamera(Context context) {
         return context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA) ||
                 context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
+    }
+
+    public static List<String> getSupportedFlashModes(Context context, Camera.Parameters parameters) {
+        //check has system feature for flash
+        if(context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
+            List<String> modes = parameters.getSupportedFlashModes();
+            if(modes.size() == 1 && modes.get(0).equals(parameters.FLASH_MODE_OFF)){
+                return null; //not supported
+            } else {
+                return modes;
+            }
+        } else {
+            return null; //not supported
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)

--- a/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
@@ -142,7 +142,8 @@ public class CameraUtil {
     public static boolean hasCamera2(Context context, boolean stillShot) {
         if (context == null) return false;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return false;
-        if (stillShot && "samsung".equals(Build.MANUFACTURER)) return false;
+        final String SAMSUNG_MANUFACTURER = "samsung";
+        if (stillShot && SAMSUNG_MANUFACTURER.equals(Build.MANUFACTURER.toLowerCase())) return false;
         try {
             CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
             String[] idList = manager.getCameraIdList();

--- a/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
@@ -142,8 +142,7 @@ public class CameraUtil {
     public static boolean hasCamera2(Context context, boolean stillShot) {
         if (context == null) return false;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return false;
-        final String SAMSUNG_MANUFACTURER = "samsung";
-        if (stillShot && SAMSUNG_MANUFACTURER.equals(Build.MANUFACTURER.toLowerCase())) return false;
+        if (stillShot && ManufacturerUtil.isSamsungDevice()) return false;
         try {
             CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
             String[] idList = manager.getCameraIdList();

--- a/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
@@ -103,6 +103,7 @@ public class CameraUtil {
     }
 
     // TODO: Take a hard look at how this works
+    // Camera2
     public static List<Integer> getSupportedFlashModes(Context context, CameraCharacteristics characteristics) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return null; //doesn't support camera2
@@ -138,9 +139,10 @@ public class CameraUtil {
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    public static boolean hasCamera2(Context context) {
+    public static boolean hasCamera2(Context context, boolean stillShot) {
         if (context == null) return false;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) return false;
+        if (stillShot && "samsung".equals(Build.MANUFACTURER)) return false;
         try {
             CameraManager manager = (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
             String[] idList = manager.getCameraIdList();

--- a/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/CameraUtil.java
@@ -105,7 +105,7 @@ public class CameraUtil {
     // TODO: Take a hard look at how this works
     public static List<Integer> getSupportedFlashModes(Context context, CameraCharacteristics characteristics) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return null;
+            return null; //doesn't support camera2
         } else if (context.getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_FLASH)) {
             Boolean flashAvailable = characteristics.get(CameraCharacteristics.FLASH_INFO_AVAILABLE);
             if (flashAvailable == null || !flashAvailable)
@@ -126,7 +126,7 @@ public class CameraUtil {
                             if (!flashModes.contains(BaseCaptureActivity.FLASH_MODE_ALWAYS_ON))
                                 flashModes.add(BaseCaptureActivity.FLASH_MODE_ALWAYS_ON);
                             break;
-                        case CameraCharacteristics.CONTROL_AE_MODE_ON: // TODO: Verify correct
+                        case CameraCharacteristics.CONTROL_AE_MODE_ON:
                             if (!flashModes.contains(BaseCaptureActivity.FLASH_MODE_OFF))
                                 flashModes.add(BaseCaptureActivity.FLASH_MODE_OFF);
                         default:

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtil.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 /**
  * Created by tomiurankar on 06/03/16.
  */
-public class ImageUtils {
+public class ImageUtil {
     /**
      * Saves byte[] array to disk
      * @param input byte array

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtils.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtils.java
@@ -60,7 +60,8 @@ public class ImageUtils {
      * @return rotated bitmap or null
      */
     public static Bitmap getRotatedBitmap(String inputFile, int reqWidth, int reqHeight) {
-        return getRotatedBitmap(inputFile, reqWidth, reqHeight, 1);
+        final int IN_SAMPLE_SIZE_DEFAULT_VAL = 1;
+        return getRotatedBitmap(inputFile, reqWidth, reqHeight, IN_SAMPLE_SIZE_DEFAULT_VAL);
     }
 
     /**

--- a/library/src/main/java/com/afollestad/materialcamera/util/ImageUtils.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ImageUtils.java
@@ -54,7 +54,18 @@ public class ImageUtils {
     }
 
     /**
-     * Rotates the bitmap per their EXIF flag.
+     * Helper function for getRotatedBitmap(String, int, int, int)
+     *
+     * @param inputFile inputFile Expects an JPEG file if corrected orientation wants to be set.
+     * @return rotated bitmap or null
+     */
+    public static Bitmap getRotatedBitmap(String inputFile, int reqWidth, int reqHeight) {
+        return getRotatedBitmap(inputFile, reqWidth, reqHeight, 1);
+    }
+
+    /**
+     * Rotates the bitmap per their EXIF flag. This is a recursive function that will
+     * be called again if the image needs to be downsized more.
      *
      * @param inputFile Expects an JPEG file if corrected orientation wants to be set.
      * @return rotated bitmap or null
@@ -67,10 +78,7 @@ public class ImageUtils {
         opts.inJustDecodeBounds = true;
         BitmapFactory.decodeFile(inputFile, opts);
         opts.inSampleSize = calculateInSampleSize(opts, reqWidth, reqHeight, inSampleSize);
-
         opts.inJustDecodeBounds = false;
-//        opts.inPreferredConfig = Bitmap.Config.RGB_565;
-//        opts.inDither = true;
 
         final Bitmap origBitmap = BitmapFactory.decodeFile(inputFile, opts);
 

--- a/library/src/main/java/com/afollestad/materialcamera/util/ManufacturerUtil.java
+++ b/library/src/main/java/com/afollestad/materialcamera/util/ManufacturerUtil.java
@@ -1,0 +1,29 @@
+package com.afollestad.materialcamera.util;
+
+import android.os.Build;
+
+/**
+ * This class exists to provide a place to define device specific information as some
+ * manufacturers/devices require specific camera setup/requirements.
+ */
+public class ManufacturerUtil {
+
+    public ManufacturerUtil() {}
+
+    // Samsung device info
+    private static final String SAMSUNG_MANUFACTURER = "samsung";
+
+    // Samsung Galaxy S3 info
+    private static final String SAMSUNG_S3_DEVICE_COMMON_PREFIX = "d2";
+    public static final Integer SAMSUNG_S3_PREVIEW_WIDTH = 640;
+    public static final Integer SAMSUNG_S3_PREVIEW_HEIGHT = 480;
+
+    // Samsung Galaxy helper functions
+    public static boolean isSamsungDevice() {
+        return SAMSUNG_MANUFACTURER.equals(Build.MANUFACTURER.toLowerCase());
+    }
+
+    public static boolean isSamsungGalaxyS3() {
+        return Build.DEVICE.startsWith(SAMSUNG_S3_DEVICE_COMMON_PREFIX);
+    }
+}


### PR DESCRIPTION
## Changelog

We've submitted a number of bug fixes that resolve all of the issues we were seeing with the stillshot branch. @sugarmanz and I tested these changes on a range of devices, and while it doesn't cover everything, we feel that all of the non edge-cases have been resolved. We're including some details of the fixes for reference.
#### Camera2 Bug

@sugarmanz fixed a bug with the Camera2 stillshot implementation that caused a "not supported" error on all of our devices. This issue was caused by the use of an uninitialized mPreviewSize.
#### Flash

The flash implementation caused a lot of errors with all of our devices. The branch was improperly checking which flash modes are available, as well as making assumptions based on whether or not the phone supported flash at all. Additionally, the flash icon would appear even if it wasn't supported -- which was very misleading.

To remedy this, we wrote more robust flash mode checks that should work on all devices. These checks include some weird ways of saying the flash is unavailable, as well as properly hiding the flash icon when flash is unavailable. We also made sure that the flash logic no longer is used in video mode, as the logic for controlling that using "torch" mode is entirely different. This should ensure that the flash feature doesn't cause any errors. 
#### Permissions Errors

@sugarmanz fixed a bug where the video camera would start if camera permissions were previously granted w/o audio permissions (most likely from using the stillshot mode). Audio permissions were requested and applied to an already open camera -- causing a crash. Requiring audio for the video mode should no longer have any issues.
#### Samsung-specific flash issues

Samsung devices using Camera2 do not handle flash well: we were encountering freezing issues and errors returning images while in stillshot mode and using flash. After doing research on how this is usually handled, we found that it is common to force the Camera1 API for stillshot on Samsung devices. We verified this with some online resources, as well as the popular cwac stillshot camrera library (which is very stable). Making this changed remedied all of the flash-specific Samsung errors. 
#### Galaxy S3 Fixes

Material-camera (current master and the stillshot fork) did not work at all in rear-facing camera mode on our test Galaxy S3. After a lot of debugging and research @sugarmanz was able to fix it in both video and stillshot mode, which required a small amount of (unfortunate) device-specific conditionals. If other Samsung phones on Camera1 are found to have these issues at a later date we can expand the conditional to include those models.
#### Bitmap preview OutOfMemory fix

We discovered an Out of Memory Error caused by large images not being properly downsized for phones with higher resolution cameras. The problem being, that with phones that take very large images (S5 has 16 MP camera), the preview image would ask for too much memory. The fix was to continually increase the `inSampleSize` until the bitmap was small enough to display. Though this was found with the S5, it is probable that this problem would occur in many devices that take really large images -- which should no longer be an issue.
### Testing

Here's the final list of working devices now that bugs are resolved.

| Device | Manufacturer | OS | Video | Stillshot | Flash | Front & Back |
| --- | :-: | :-: | :-: | :-: | :-: | :-: |
| Nexus 6p | Huewei | 6.0.1 | ✓ | ✓ | ✓ | ✓ |
| Nexus 5 | LG | 6.0.1 | ✓ | ✓ | ✓ | ✓ |
| Droid Razr Maxx | Motorolla | 4.4.2 | ✓ | ✓ | ✓ | ✓ |
| Galaxy S6 | Samsung | 6.0.1 | ✓ | ✓ | ✓ | ✓ |
| Galaxy S5 | Samsung | 5.0.0 | ✓ | ✓ | ✓ | ✓ |
| Galaxy S3 (SCH-I525) | Samsung | 4.4.2 | ✓ | ✓ | ✓ | ✓ |
### Going Forward

We finally feel pretty confident that these new features won't cause any obvious errors, and shouldn't interfere with the existing video functionality or make it less stable. We're hoping @afollestad can take a look and hopefully get these features added soon. 
